### PR TITLE
Fix syntax issue in check_process breaking CI tests..

### DIFF
--- a/check_process
+++ b/check_process
@@ -22,7 +22,7 @@
 		# incorrect_path=1
 		port_already_use=0
 		change_url=0
-;; Levels
+;;; Levels
 	# If the level 5 (Package linter) is forced to 1. Please add justifications here.
 	Level 5=auto
 ;;; Options


### PR DESCRIPTION
Randomly checking CI results and I realize the app should be level 7 ... 

https://ci-apps.yunohost.org/ci/job/2253

But it's failing CI tests because there's a test suite called "Levels" which fails ... but that's just a syntax issue in the check_process file ...