### PR TITLE
Remove autoupdate as Gogs is not supported.

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -47,8 +47,6 @@ ram.runtime = "50M"
     url = "https://notabug.org/halcyon-suite/halcyon/archive/2.4.9.tar.gz"
     sha256 = "5fa0b6f9bb850b4d94f4d210887559fccf9f230baa898f03f7f167c29f3c8c1e"
 
-    autoupdate.strategy = "latest_github_tag"
-
     [resources.system_user]
 
     [resources.install_dir]


### PR DESCRIPTION
## Problem

- Upstream is hosted on Gogs

## Solution

- None at the moment, disable autoupdate.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
